### PR TITLE
docs; add example of `PARTITION BY` in table/2

### DIFF
--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -659,7 +659,13 @@ defmodule Ecto.Migration do
         add :name, :string
         add :price, :decimal
       end
-
+      
+      create table("daily_prices", primary_key: false, options: "PARTITION BY RANGE (date)) do
+        add :name, :string, primary_key: true
+        add :date, :date, primary_key: true
+        add :price, :decimal
+      end
+      
   ## Options
 
     * `:primary_key` - when `false`, a primary key field is not generated on table
@@ -674,7 +680,8 @@ defmodule Ecto.Migration do
       overridden in said constraints/references.
     * `:comment` - adds a comment to the table.
     * `:options` - provide custom options that will be appended after the generated
-      statement. For example, "WITH", "INHERITS", or "ON COMMIT" clauses.
+      statement. For example, "WITH", "INHERITS", or "ON COMMIT" clauses. For PostgreSQL
+      "PARTITION BY" can be provided for table partitioning.
 
   """
   def table(name, opts \\ [])

--- a/lib/ecto/migration.ex
+++ b/lib/ecto/migration.ex
@@ -660,7 +660,7 @@ defmodule Ecto.Migration do
         add :price, :decimal
       end
       
-      create table("daily_prices", primary_key: false, options: "PARTITION BY RANGE (date)) do
+      create table("daily_prices", primary_key: false, options: "PARTITION BY RANGE (date)") do
         add :name, :string, primary_key: true
         add :date, :date, primary_key: true
         add :price, :decimal


### PR DESCRIPTION
Add an example of PARTITION BY option for PostgreSQL databases in table/2 function